### PR TITLE
Update various colors for dark theme to match figma

### DIFF
--- a/components/NetworkAsset/NetworkAssetTitle/RewardsAndPoints/index.tsx
+++ b/components/NetworkAsset/NetworkAssetTitle/RewardsAndPoints/index.tsx
@@ -20,6 +20,7 @@ function RewardsAndPoints() {
         gap={3}
         align="center"
         w="100%"
+        bg="backgroundSecondary"
       >
         <Flex gap={2} align="center">
           <Text variant="paragraph" whiteSpace="nowrap">

--- a/components/shared/MulitiIcon/index.tsx
+++ b/components/shared/MulitiIcon/index.tsx
@@ -13,11 +13,11 @@ export function MultiIcon({ icons, ...props }: MultiIconProps) {
           position="absolute"
           top="0"
           left={`${index * 20}px`}
-          bg="white"
-          borderRadius="100px"
+          bg="iconBackground"
           p="4px"
+          borderRadius="100px"
           border="1px solid"
-          borderColor="border"
+          borderColor="borderLight"
         >
           {icon}
         </Flex>

--- a/components/shared/RewardsAndPoints/RewardsTooltip/index.tsx
+++ b/components/shared/RewardsAndPoints/RewardsTooltip/index.tsx
@@ -19,7 +19,7 @@ function RewardsTooltip({ tokenKey, children, ...chakraProps }: RewardsTooltipPr
           onClick={(e) => e.stopPropagation()} // Prevent event bubbling
           w="260px"
           p={0}
-          bg="backgroundAlternate"
+          bg="iconBackground"
           borderRadius="10px"
           boxShadow="none"
           border="1px solid"

--- a/components/shared/RewardsAndPoints/RewardsTooltipContent/index.tsx
+++ b/components/shared/RewardsAndPoints/RewardsTooltipContent/index.tsx
@@ -26,7 +26,7 @@ export function RewardsTooltipContent({
 
       {/* Default Yield */}
       <Flex direction="column">
-        <Text variant="smallParagraph" color="tooltipLabel">
+        <Text variant="smallParagraph" color="textSecondary">
           Default Yield
         </Text>
         <Flex align="center" justify="space-between" mt={1}>
@@ -42,12 +42,12 @@ export function RewardsTooltipContent({
         </Flex>
       </Flex>
 
-      <Divider />
+      <Divider borderColor="borderLight" />
 
       {/* Token Incentives */}
       <Flex direction="column">
         <Flex align="center" gap={2}>
-          <Text variant="smallParagraph" color="tooltipLabel">
+          <Text variant="smallParagraph" color="textSecondary">
             Token Incentives
           </Text>
           <IonTooltip label="APYs are calculated as (APY = Annualized Incentives Value / Current TVL)">
@@ -81,11 +81,11 @@ export function RewardsTooltipContent({
         ))}
       </Flex>
 
-      <Divider />
+      <Divider borderColor="borderLight" />
 
       {/* Rewards */}
       <Flex direction="column">
-        <Text variant="smallParagraph" color="tooltipLabel">
+        <Text variant="smallParagraph" color="textSecondary">
           Rewards
         </Text>
         {rewards.map((reward) => (
@@ -103,7 +103,7 @@ export function RewardsTooltipContent({
         ))}
       </Flex>
 
-      <Divider />
+      <Divider borderColor="borderLight" />
 
       {/* Net Apy */}
       <IonTooltip

--- a/styles/theme/tokens.ts
+++ b/styles/theme/tokens.ts
@@ -36,6 +36,10 @@ export const semanticTokens = {
       default: 'neutral.500',
       _dark: 'darkMode.300',
     },
+    iconBackground: {
+      default: 'neutral.200',
+      _dark: 'darkMode.300',
+    },
     text: {
       default: 'darkMode.500',
       _dark: 'white',


### PR DESCRIPTION
# Update colors for dark theme
Updates various colors for dark theme to match the Figma designs. This issue was originally intended to update just tokens but there were other colors that also needed to be updated. 

## Notes
There are various colors that were implemented before the designs for dark mode were complete on Figma. This PR updates some of those colors. 

#### Updated token icon backgrounds
![image](https://github.com/user-attachments/assets/3efeb9f2-6a60-4a0f-9d4e-c5e8d642a4a2)

#### Updated background for rewards & points card
![image](https://github.com/user-attachments/assets/38705ba9-185b-4744-9af5-150f587d4176)

#### Update background and divider for rewards tooltip
![image](https://github.com/user-attachments/assets/ba0cad77-5a45-4900-9411-a0536b57d112)

## References
- https://www.figma.com/design/9o1l6YKZ5yKtCgGeI8rYkp/Nucleus?node-id=15574-60784&node-type=frame&t=Mdgzn35v6WaucjCy-0

