### PR TITLE
fix: fees when not bridging

### DIFF
--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
@@ -1,9 +1,19 @@
 import { RootState } from '@/store'
-import { selectFormattedPreviewFee, selectPreviewFeeLoading } from '@/store/slices/networkAssets'
+import {
+  selectFormattedPreviewFee,
+  selectNetworkAssetConfig,
+  selectPreviewFeeLoading,
+  selectSourceChainKey,
+} from '@/store/slices/networkAssets'
 import { ConnectedProps, connect } from 'react-redux'
 
 const mapState = (state: RootState, ownProps: SummaryOwnProps) => {
-  return { fees: selectFormattedPreviewFee(state), loading: selectPreviewFeeLoading(state) }
+  let selectedChainKey = selectSourceChainKey(state)
+  const networkAssetConfig = selectNetworkAssetConfig(state)
+  const receiveOn = networkAssetConfig?.receiveOn
+  const isSameChain = selectedChainKey === receiveOn
+
+  return { fees: selectFormattedPreviewFee(state), loading: selectPreviewFeeLoading(state), isSameChain }
 }
 
 const mapDispatch = {}

--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
@@ -4,7 +4,10 @@ import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex, Text } from '@chakra-ui/react'
 import { SummaryConnector } from './connector'
 
-function Summary({ fees, loading }: SummaryConnector.Props) {
+function Summary({ fees, loading, isSameChain }: SummaryConnector.Props) {
+  const tooltipLabel = isSameChain
+    ? 'No fees are charged when depositing and minting on the same chain'
+    : 'Fees are charged by the underlying bridge provider such as LayerZero or Hyperlane'
   return (
     <Flex direction="column" gap={3}>
       <Flex align="center" justify="space-between">
@@ -12,7 +15,7 @@ function Summary({ fees, loading }: SummaryConnector.Props) {
           <Text variant="paragraph" color="disabledText">
             Fees
           </Text>
-          <IonTooltip label="Fees are charged by the underlying bridge provider such as LayerZero or Hyperlane">
+          <IonTooltip label={tooltipLabel}>
             <InfoOutlineIcon color="infoIcon" mt={'2px'} fontSize="sm" />
           </IonTooltip>
         </Flex>


### PR DESCRIPTION
fix(components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts,-components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx): 
created a check to see if assets require a bridge. Render tooltip text based on the isSameChain bool

[Ticket](https://www.notion.so/molecularlabs/Fees-when-not-bridging-10bdbfbd012c808bbc0dd78fa55db75d)

Bridge Required
![Screenshot 2024-10-14 at 1 03 22 PM](https://github.com/user-attachments/assets/4f313abd-7442-4234-9f80-950589e995fd)


No bridge required
![Screenshot 2024-10-14 at 1 18 55 PM](https://github.com/user-attachments/assets/e5f35734-4939-4aaa-b95b-8b5e2e38eb34)

