### PR TITLE
Fix/74 show conversion ratio on mint

### DIFF
--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
@@ -1,23 +1,41 @@
+import { ConnectedProps, connect } from 'react-redux'
+
 import { RootState } from '@/store'
+import { tokensConfig } from '@/config/tokens'
+
+import { bigIntToNumberAsString } from '@/utils/bigint'
 import {
   selectFormattedPreviewFee,
-  selectFormattedTokenRateInQuote,
+  selectTokenRateInQuote,
+  selectTokenRateInQuoteLoading,
   selectNetworkAssetConfig,
   selectPreviewFeeLoading,
   selectSourceChainKey,
 } from '@/store/slices/networkAssets'
-import { ConnectedProps, connect } from 'react-redux'
+import { selectNetworkAssetFromRoute } from '@/store/slices/router'
 
 const mapState = (state: RootState, ownProps: SummaryOwnProps) => {
   let selectedChainKey = selectSourceChainKey(state)
   const networkAssetConfig = selectNetworkAssetConfig(state)
+  const tokenRateInQuote = selectTokenRateInQuote(state)
+  const networkAssetFromRoute = selectNetworkAssetFromRoute(state)
+  const networkAssetName = networkAssetFromRoute ? tokensConfig[networkAssetFromRoute].name : ''
+  const exchangeRate = tokenRateInQuote
+    ? bigIntToNumberAsString(BigInt(tokenRateInQuote), { maximumFractionDigits: 18 })
+    : '0.00'
+  const truncatedExchangeRate = tokenRateInQuote
+    ? bigIntToNumberAsString(BigInt(tokenRateInQuote), { maximumFractionDigits: 4 })
+    : '0.00'
   const receiveOn = networkAssetConfig?.receiveOn
   const isSameChain = selectedChainKey === receiveOn
 
   return {
     fees: selectFormattedPreviewFee(state),
     loading: selectPreviewFeeLoading(state),
-    exchangeRate: selectFormattedTokenRateInQuote(state),
+    exchangeRate,
+    truncatedExchangeRate,
+    exchangeRateLoading: selectTokenRateInQuoteLoading(state),
+    networkAssetName,
     isSameChain,
   }
 }

--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/connector.ts
@@ -1,6 +1,7 @@
 import { RootState } from '@/store'
 import {
   selectFormattedPreviewFee,
+  selectFormattedTokenRateInQuote,
   selectNetworkAssetConfig,
   selectPreviewFeeLoading,
   selectSourceChainKey,
@@ -13,7 +14,12 @@ const mapState = (state: RootState, ownProps: SummaryOwnProps) => {
   const receiveOn = networkAssetConfig?.receiveOn
   const isSameChain = selectedChainKey === receiveOn
 
-  return { fees: selectFormattedPreviewFee(state), loading: selectPreviewFeeLoading(state), isSameChain }
+  return {
+    fees: selectFormattedPreviewFee(state),
+    loading: selectPreviewFeeLoading(state),
+    exchangeRate: selectFormattedTokenRateInQuote(state),
+    isSameChain,
+  }
 }
 
 const mapDispatch = {}

--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
@@ -4,10 +4,19 @@ import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex, Text } from '@chakra-ui/react'
 import { SummaryConnector } from './connector'
 
-function Summary({ fees, loading, isSameChain }: SummaryConnector.Props) {
+function Summary({
+  fees,
+  loading,
+  isSameChain,
+  exchangeRate,
+  truncatedExchangeRate,
+  exchangeRateLoading,
+  networkAssetName,
+}: SummaryConnector.Props) {
   const tooltipLabel = isSameChain
     ? 'No fees are charged when depositing and minting on the same chain'
     : 'Fees are charged by the underlying bridge provider such as LayerZero or Hyperlane'
+  const exchangeRateTooltipLabel = 'The exchange rate is the ratio of the deposit amount to the minted amount.'
   return (
     <Flex direction="column" gap={3}>
       <Flex align="center" justify="space-between">
@@ -15,14 +24,16 @@ function Summary({ fees, loading, isSameChain }: SummaryConnector.Props) {
           <Text variant="paragraph" color="disabledText">
             Exchange Rate
           </Text>
-          <IonTooltip label={tooltipLabel}>
+          <IonTooltip label={exchangeRateTooltipLabel}>
             <InfoOutlineIcon color="infoIcon" mt={'2px'} fontSize="sm" />
           </IonTooltip>
         </Flex>
-        <IonSkeleton minW="75px" isLoaded={!loading}>
-          <Text textAlign="right" variant="paragraph">
-            {fees}
-          </Text>
+        <IonSkeleton minW="35px" isLoaded={!exchangeRateLoading}>
+          <IonTooltip label={exchangeRate}>
+            <Text textAlign="right" variant="paragraph">
+              {`WETH / ${networkAssetName} ${truncatedExchangeRate}`}
+            </Text>
+          </IonTooltip>
         </IonSkeleton>
       </Flex>
       <Flex align="center" justify="space-between">

--- a/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/shared/Summary/index.tsx
@@ -13,6 +13,21 @@ function Summary({ fees, loading, isSameChain }: SummaryConnector.Props) {
       <Flex align="center" justify="space-between">
         <Flex color="secondaryText" gap={2} align="center">
           <Text variant="paragraph" color="disabledText">
+            Exchange Rate
+          </Text>
+          <IonTooltip label={tooltipLabel}>
+            <InfoOutlineIcon color="infoIcon" mt={'2px'} fontSize="sm" />
+          </IonTooltip>
+        </Flex>
+        <IonSkeleton minW="75px" isLoaded={!loading}>
+          <Text textAlign="right" variant="paragraph">
+            {fees}
+          </Text>
+        </IonSkeleton>
+      </Flex>
+      <Flex align="center" justify="space-between">
+        <Flex color="secondaryText" gap={2} align="center">
+          <Text variant="paragraph" color="disabledText">
             Fees
           </Text>
           <IonTooltip label={tooltipLabel}>

--- a/store/slices/networkAssets/selectors.ts
+++ b/store/slices/networkAssets/selectors.ts
@@ -520,6 +520,13 @@ export const selectTokenRateInQuoteLoading = (state: RootState) => {
   return bridgesState.tokenRate.loading
 }
 
+export const selectFormattedTokenRateInQuote = (state: RootState): string => {
+  const tokenRateInQuote = selectTokenRateInQuote(state)
+  if (!tokenRateInQuote) return '0.00'
+  const formattedTokenRateInQuote = bigIntToNumberAsString(BigInt(tokenRateInQuote))
+  return formattedTokenRateInQuote
+}
+
 /////////////////////////////////////////////////////////////////////
 // Balance
 /////////////////////////////////////////////////////////////////////

--- a/store/slices/networkAssets/selectors.ts
+++ b/store/slices/networkAssets/selectors.ts
@@ -520,13 +520,6 @@ export const selectTokenRateInQuoteLoading = (state: RootState) => {
   return bridgesState.tokenRate.loading
 }
 
-export const selectFormattedTokenRateInQuote = (state: RootState): string => {
-  const tokenRateInQuote = selectTokenRateInQuote(state)
-  if (!tokenRateInQuote) return '0.00'
-  const formattedTokenRateInQuote = bigIntToNumberAsString(BigInt(tokenRateInQuote))
-  return formattedTokenRateInQuote
-}
-
 /////////////////////////////////////////////////////////////////////
 // Balance
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added Exchange Rate with tooltip
Added formatted versions of tokenRateInQuote. 
One truncated is to be displayed on the dashboard, and the full exchangeRate is displayed on hover.

![token conversion ratio on mint](https://github.com/user-attachments/assets/145ecf39-91f9-4400-aca7-bb456f417899)