### PR TITLE
Fix rewards info on dashboard

### DIFF
--- a/components/NetworkAssetList/NetworkAssetItem/index.tsx
+++ b/components/NetworkAssetList/NetworkAssetItem/index.tsx
@@ -83,6 +83,7 @@ function NetworkAssetItem({
           <Text variant="bigParagraph" color="disabledText">
             {chainName}
           </Text>
+          {isExternal && <ExternalLinkIcon color="disabledText" fontSize="16px" />}
         </Flex>
 
         {!comingSoon ? (
@@ -110,29 +111,13 @@ function NetworkAssetItem({
                 </IonSkeleton>
               </Flex>
             </Flex>
-            {isExternal ? (
-              <Flex gap={1}>
-                <Text
-                  fontSize="14px"
-                  variant="link"
-                  display="flex"
-                  fontFamily="var(--font-ppformula)"
-                  gap={1}
-                  textDecoration="underline"
-                  textUnderlineOffset={2}
-                >
-                  {`Mint on ${chainName}`} <ExternalLinkIcon fontSize="16px" />
-                </Text>
-              </Flex>
-            ) : (
-              <Flex direction="column" gap={1} w="fit-content">
-                {/* Rewards */}
-                <Text variant="smallParagraph">Rewards</Text>
-                <RewardsTooltip tokenKey={networkAssetKey}>
-                  <RewardsIconRow w="fit-content" tokenKey={networkAssetKey} />
-                </RewardsTooltip>
-              </Flex>
-            )}
+            <Flex direction="column" gap={1} w="fit-content">
+              {/* Rewards */}
+              <Text variant="smallParagraph">Rewards</Text>
+              <RewardsTooltip tokenKey={networkAssetKey}>
+                <RewardsIconRow w="fit-content" tokenKey={networkAssetKey} />
+              </RewardsTooltip>
+            </Flex>
           </>
         ) : (
           <Flex mb={6}>

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -44,24 +44,7 @@ const defaultEthVaultAssets = [
 // TODO: Break into two types. Internal and External where mint and redeem take place in the Nucleus app or a partners app respectively
 const mainnetNetworkAssets: NetworkAssets = {
   [TokenKey.SSETH]: {
-    apys: {
-      [TokenKey.ISEI]: [
-        {
-          tokenKey: TokenKey.ISEI,
-          startDate: 1726199999000, // 9/12/24 11:59:59pm EST
-          endDate: 1734065999000, // 12/12/24 11:59:59pm EST
-          distribution: 62_500, // $62,500
-        },
-      ],
-      [TokenKey.DINERO]: [
-        {
-          tokenKey: TokenKey.DINERO,
-          startDate: 1726199999000, // 9/12/24 11:59:59pm EST
-          endDate: 1734065999000, // 12/12/24 11:59:59pm EST
-          distribution: 62_500, // $62,500
-        },
-      ],
-    },
+    apys: {},
     chain: ChainKey.SEI,
     contracts: {
       teller: '0x97D0B97A9FA017f8aD2565a5c6AED5745f3918b9',
@@ -399,11 +382,6 @@ const mainnetNetworkAssets: NetworkAssets = {
         name: 'Nucleus',
         pointsMultiplier: 3,
       },
-      {
-        key: PointSystemKey.SWELL,
-        name: 'Swell',
-        pointsMultiplier: 3,
-      },
     ],
     redeem: {
       withdrawalFee: defaultWithdrawalFee,
@@ -456,7 +434,13 @@ const mainnetNetworkAssets: NetworkAssets = {
       boringVault: '0x19e099B7aEd41FA52718D780dDA74678113C0b32',
     },
     receiveOn: ChainKey.ETHEREUM,
-    points: [],
+    points: [
+      {
+        key: PointSystemKey.NUCLEUS,
+        name: 'Nucleus',
+        pointsMultiplier: 1,
+      },
+    ],
     redeem: {
       withdrawalFee: defaultWithdrawalFee,
       redemptionSourceChain: ChainKey.ETHEREUM,

--- a/config/tokens.ts
+++ b/config/tokens.ts
@@ -160,7 +160,7 @@ export const tokensConfig: Record<TokenKey, Token> = {
   },
   [TokenKey.UNIFIETH]: {
     key: TokenKey.UNIFIETH,
-    name: 'UniFiETH',
+    name: 'unifiETH',
     symbol: 'UNIFIETH',
     addresses: {
       [ChainKey.UNIFI]: '0x196ead472583bc1e9af7a05f860d9857e1bd3dcc',


### PR DESCRIPTION
### Requirements
- Change to new design that shows with rewards and external link icon
- For UnifiETH, earnETH, tETH cards
  - Reward Section should show the following Nucleus points multiplier
  - earnETH 
    - Nucleus 3x 
  - unifiETH
    - Nucleus 2x 
  - tETH
    - Nucleus 1x

- For ssETH, delete the DINERO and iSEI token images from the reward cards
- <img width="190" alt="Image" src="https://github.com/user-attachments/assets/4d97f8ba-52a0-473e-8fad-723cab054a6e" />
  - <img width="145" alt="Image" src="https://github.com/user-attachments/assets/eeaa3e07-c854-4aae-a612-872c5358d54a" />

### Figma
- https://www.figma.com/design/9o1l6YKZ5yKtCgGeI8rYkp/Nucleus?node-id=10211-169863&p=f&t=GR00vIo91EBauLpF-0