### PR TITLE
refactor: rename withdrawal fee to withdraw slippage across component…

### DIFF
--- a/components/NetworkAsset/MintAndRedeem/Redeem/RedeemSummary/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/Redeem/RedeemSummary/index.tsx
@@ -23,10 +23,10 @@ export const RedeemSummaryCopy = {
     tooltip:
       'The current exchange rate used to calculate the redemption price that is not inclusive of the withdrawal fee.',
   },
-  withdrawFee: {
-    label: 'Withdraw Fee',
+  withdrawSlippage: {
+    label: 'Withdraw Slippage',
     tooltip:
-      'Withdraw fees are applied in order to incentivize solvers to process withdraw orders into arbitrary requested assets.',
+      'Withdrawal slippage is the amount of slippage that is applied to the withdrawal. This slippage is applied in order to incentivize solvers to process withdraw orders into arbitrary requested assets.',
   },
   deadline: {
     label: 'Deadline',
@@ -42,7 +42,7 @@ function RedeemSummary({}: RedeemSummaryConnector.Props) {
     redemptionSourceChainKey,
     sharesTokenKey,
     redeemAmountAsBigInt,
-    withdrawalFee,
+    withdrawSlippage,
     isBridgeRequired,
     receiveToken,
     nativeAsset,
@@ -123,15 +123,15 @@ function RedeemSummary({}: RedeemSummaryConnector.Props) {
             <Flex align="center" justify="space-between">
               <Flex color="secondaryText" gap={2} align="center">
                 <Text variant="paragraph" color="disabledText">
-                  {RedeemSummaryCopy.withdrawFee.label}
+                  {RedeemSummaryCopy.withdrawSlippage.label}
                 </Text>
-                <IonTooltip label={RedeemSummaryCopy.withdrawFee.tooltip}>
+                <IonTooltip label={RedeemSummaryCopy.withdrawSlippage.tooltip}>
                   <InfoOutlineIcon color="infoIcon" mt={'2px'} fontSize="sm" />
                 </IonTooltip>
               </Flex>
               <IonSkeleton minW="75px" isLoaded={true}>
                 <Text textAlign="right" variant="paragraph" color="disabledText">
-                  {withdrawalFee}%
+                  {Number(withdrawSlippage).toFixed(2)}%
                 </Text>
               </IonSkeleton>
             </Flex>

--- a/components/NetworkAsset/MintAndRedeem/Redeem/RedeemSummaryCard/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/Redeem/RedeemSummaryCard/index.tsx
@@ -24,7 +24,7 @@ export type RedeemSummaryCardProps = {
   redeemAmount: string
   receiveAmount: string
   bridgeFee?: string
-  withdrawFee: string
+  withdrawSlippage: string
   deadline: string
   total?: string
   totalUsd?: string
@@ -36,7 +36,7 @@ const RedeemSummaryCard = () => {
     usePreviewFee,
     withdrawalDestinationChainKey,
     redemptionSourceChainKey,
-    withdrawalFee,
+    withdrawSlippage,
     isBridgeRequired,
     receiveToken,
     sharesTokenKey,
@@ -120,9 +120,9 @@ const RedeemSummaryCard = () => {
                   fullValue={`${tokenRateInQuote?.rateInQuoteSafeAsString} ${receiveToken?.name} / ${sharesTokenKey}`}
                 />
                 <SummaryRow
-                  label={RedeemSummaryCopy.withdrawFee.label}
-                  tooltip={RedeemSummaryCopy.withdrawFee.tooltip}
-                  value={`${withdrawalFee}%`}
+                  label={RedeemSummaryCopy.withdrawSlippage.label}
+                  tooltip={RedeemSummaryCopy.withdrawSlippage.tooltip}
+                  value={`${withdrawSlippage}%`}
                 />
                 <SummaryRow
                   label={RedeemSummaryCopy.deadline.label}

--- a/components/NetworkAsset/MintAndRedeem/Redeem/RedeemTokenDestination/index.tsx
+++ b/components/NetworkAsset/MintAndRedeem/Redeem/RedeemTokenDestination/index.tsx
@@ -3,9 +3,9 @@ import { IonCard } from '@/components/shared/IonCard'
 import { IonSkeleton } from '@/components/shared/IonSkeleton'
 import { IonTooltip } from '@/components/shared/IonTooltip'
 import { useGetRateInQuoteSafeQuery } from '@/store/slices/accountantApi'
-import { selectWithdrawalFee } from '@/store/slices/networkAssets'
+import { selectWithdrawSlippage } from '@/store/slices/networkAssets'
 import { bigIntToNumberAsString, WAD } from '@/utils/bigint'
-import { applyWithdrawalFeeReduction } from '@/utils/withdrawal'
+import { applyWithdrawSlippageReduction } from '@/utils/withdrawal'
 import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex, Input, Text } from '@chakra-ui/react'
 import { useSelector } from 'react-redux'
@@ -25,7 +25,7 @@ function RedeemTokenDestination({
   redeemAmountAsBigInt,
   chainId,
 }: RedeemTokenDestinationConnector.Props) {
-  const withdrawalFee = useSelector(selectWithdrawalFee)
+  const withdrawSlippage = useSelector(selectWithdrawSlippage)
 
   const { data: tokenRateInQuote, isSuccess: tokenRateInQuoteSuccess } = useGetRateInQuoteSafeQuery(
     {
@@ -40,7 +40,7 @@ function RedeemTokenDestination({
 
   // Calculate rate with 0.02% fee
   const rateInQuoteWithFee = tokenRateInQuote?.rateInQuoteSafe
-    ? applyWithdrawalFeeReduction(BigInt(tokenRateInQuote?.rateInQuoteSafe), withdrawalFee)
+    ? applyWithdrawSlippageReduction(BigInt(tokenRateInQuote?.rateInQuoteSafe), withdrawSlippage)
     : BigInt(0)
 
   // Calculate redeem amount using rate

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,7 +1,7 @@
 export const docsUrl = 'https://docs.nucleusearn.io/'
 export const discordUrl = 'https://discord.com/invite/CjQqUgPA6Y'
 export const nativeAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-export const atomicQueueContractAddress = '0xc7287780bfa0C5D2dD74e3e51E238B1cd9B221ee'
+export const atomicQueueContractAddress = '0x228c44bb4885c6633f4b6c83f14622f37d5112e5'
 export const etherscanBaseUrl = 'https://etherscan.io'
 export const seiExplorerBaseUrl = 'https://seitrace.com'
 export const rariExplorerBaseUrl = 'https://mainnet.explorer.rarichain.org'
@@ -18,7 +18,7 @@ export const supraScanBaseUrl = 'https://suprascan.io/tx/'
 export const hardcodedApy = 4 // 4%
 export const msInOneYear = 31_556_952_000
 export const mintSlippage = 0.005 // 0.5%
-export const defaultWithdrawalFee = 0.2 // 0.2%
+export const defaultWithdrawSlippage = 0.2 // 0.2%
 export const pollBalanceInterval = 30_000 // 30 seconds
 export const pollBalanceAfterTransactionInterval = 10_000 // 10 seconds
 export const pollBalanceAfterTransactionAttempts = 12 // 2 minutes worth of attempts

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -5,7 +5,7 @@ import { TokenKey } from '@/types/TokenKey'
 import { boba, sei } from 'wagmi/chains'
 import {
   bobaExplorerBaseURL,
-  defaultWithdrawalFee,
+  defaultWithdrawSlippage,
   etherscanBaseUrl,
   formExplorerBaseUrl,
   hyperlaneBaseUrl,
@@ -99,38 +99,38 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: 1,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee,
+            withdrawSlippage: 1,
           },
           [TokenKey.RSWETH]: {
             token: tokensConfig[TokenKey.RSWETH],
-            withdrawalFee: defaultWithdrawalFee,
+            withdrawSlippage: 1,
           },
           [TokenKey.EZETH]: {
             token: tokensConfig[TokenKey.EZETH],
-            withdrawalFee: defaultWithdrawalFee,
+            withdrawSlippage: 1,
           },
           [TokenKey.WEETH]: {
             token: tokensConfig[TokenKey.WEETH],
-            withdrawalFee: defaultWithdrawalFee,
+            withdrawSlippage: 1,
           },
           [TokenKey.WSTETH]: {
             token: tokensConfig[TokenKey.WSTETH],
-            withdrawalFee: defaultWithdrawalFee,
+            withdrawSlippage: 1,
           },
         },
         [ChainKey.BOBA]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: 0.01,
+            withdrawSlippage: 1,
           },
         },
       },
       withdrawalChain: ChainKey.ETHEREUM, // Call to teller to withdraw from SSETH to Want Token
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
     },
     receiveOn: ChainKey.BOBA,
     showRewardsAndHistory: false,
@@ -209,20 +209,20 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.SFRXETH]: {
             token: tokensConfig[TokenKey.SFRXETH],
-            withdrawalFee: 0.01, // Custom fee for SFRXETH
+            withdrawSlippage: 0.01, // Custom fee for SFRXETH
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: 0.01, // Custom fee for APXETH
+            withdrawSlippage: 0.01, // Custom fee for APXETH
           },
         },
       },
       withdrawalChain: ChainKey.ETHEREUM, // Call to teller to withdraw from SSETH to Want Token
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
     },
     receiveOn: ChainKey.SEI,
     showRewardsAndHistory: true,
@@ -349,30 +349,30 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.WSTETH]: {
             token: tokensConfig[TokenKey.WSTETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.PZETH]: {
             token: tokensConfig[TokenKey.PZETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.EZETH]: {
             token: tokensConfig[TokenKey.EZETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
         [ChainKey.FORM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: 0.02,
+            withdrawSlippage: 0.02,
           },
         },
       },
       withdrawalChain: ChainKey.ETHEREUM, // Call to teller to withdraw from SSETH to Want Token
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
     },
     receiveOn: ChainKey.FORM,
     showRewardsAndHistory: false,
@@ -457,42 +457,42 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.EZETH]: {
             token: tokensConfig[TokenKey.EZETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.WSTETH]: {
             token: tokensConfig[TokenKey.WSTETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.RSWETH]: {
             token: tokensConfig[TokenKey.RSWETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.RSETH]: {
             token: tokensConfig[TokenKey.RSETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.WEETH]: {
             token: tokensConfig[TokenKey.WEETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
         [ChainKey.RARI]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: 0, // Default 0.2%,
+            withdrawSlippage: 0, // Default 0.2%,
           },
         },
       },
       withdrawalChain: ChainKey.ETHEREUM, // Call to teller to withdraw from shares token to want token
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
     },
     receiveOn: ChainKey.RARI,
     redeemComingSoon: false,
@@ -571,7 +571,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.UNIFI,
       redemptionSourceChains: {
         [ChainKey.UNIFI]: {
@@ -597,15 +597,15 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.SFRXETH]: {
             token: tokensConfig[TokenKey.SFRXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },
@@ -662,7 +662,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.ETHEREUM,
       redemptionSourceChains: {
         [ChainKey.ETHEREUM]: {
@@ -684,15 +684,15 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.SFRXETH]: {
             token: tokensConfig[TokenKey.SFRXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },
@@ -747,7 +747,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.ETHEREUM,
       redemptionSourceChains: {
         [ChainKey.ETHEREUM]: {
@@ -769,15 +769,15 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.SFRXETH]: {
             token: tokensConfig[TokenKey.SFRXETH],
-            withdrawalFee: defaultWithdrawalFee, /// Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, /// Default 0.2%,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },
@@ -866,7 +866,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.ETHEREUM,
       redemptionSourceChains: {
         [ChainKey.ETHEREUM]: {
@@ -888,15 +888,15 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.SFRXETH]: {
             token: tokensConfig[TokenKey.SFRXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
           [TokenKey.APXETH]: {
             token: tokensConfig[TokenKey.APXETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },
@@ -951,7 +951,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.ETHEREUM,
       redemptionSourceChains: {
         [ChainKey.ETHEREUM]: {
@@ -973,7 +973,7 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.WETH]: {
             token: tokensConfig[TokenKey.WETH],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },
@@ -1023,7 +1023,7 @@ const mainnetNetworkAssets: NetworkAssets = {
       },
     ],
     redeem: {
-      withdrawalFee: defaultWithdrawalFee,
+      withdrawSlippage: defaultWithdrawSlippage,
       redemptionSourceChain: ChainKey.ETHEREUM,
       redemptionSourceChains: {
         [ChainKey.ETHEREUM]: {
@@ -1045,7 +1045,7 @@ const mainnetNetworkAssets: NetworkAssets = {
         [ChainKey.ETHEREUM]: {
           [TokenKey.SUSN]: {
             token: tokensConfig[TokenKey.SUSN],
-            withdrawalFee: defaultWithdrawalFee, // Default 0.2%,
+            withdrawSlippage: defaultWithdrawSlippage, // Default 0.2%,
           },
         },
       },

--- a/hooks/redeem/useRedeemData.ts
+++ b/hooks/redeem/useRedeemData.ts
@@ -11,10 +11,10 @@ import {
   selectRedeemBridgeData,
   selectRedemptionSourceChainId,
   selectWantAssetAddress,
-  selectWithdrawalFee,
+  selectWithdrawSlippage,
 } from '@/store/slices/networkAssets/selectors'
 import { useGetPreviewFeeQuery } from '@/store/slices/tellerApi'
-import { applyWithdrawalFeeReduction } from '@/utils/withdrawal'
+import { applyWithdrawSlippageReduction } from '@/utils/withdrawal'
 import { useSelector } from 'react-redux'
 import { Address } from 'viem'
 
@@ -58,9 +58,9 @@ export const useRedeemData = () => {
   )
 
   // Apply Fee to Token Rate in Quote
-  const withdrawalFee = useSelector(selectWithdrawalFee)
+  const withdrawSlippage = useSelector(selectWithdrawSlippage)
   const rateInQuoteWithFee = useGetTokenRateInQuote.data?.rateInQuoteSafe
-    ? applyWithdrawalFeeReduction(BigInt(useGetTokenRateInQuote.data?.rateInQuoteSafe), withdrawalFee)
+    ? applyWithdrawSlippageReduction(BigInt(useGetTokenRateInQuote.data?.rateInQuoteSafe), withdrawSlippage)
     : BigInt(0)
 
   // Bridge Preview Fee Selectors. Note: Only applies to withdrawal with Bridge
@@ -89,7 +89,7 @@ export const useRedeemData = () => {
     useAllowance,
     useGetTokenRateInQuote,
     rateInQuoteWithFee,
-    withdrawalFee,
+    withdrawSlippage,
     usePreviewFee,
   }
 }

--- a/hooks/redeem/useRedeemSummaryData.ts
+++ b/hooks/redeem/useRedeemSummaryData.ts
@@ -11,7 +11,7 @@ import {
   selectRedeemAmountAsBigInt,
   selectRedemptionDestinationChainKey,
   selectRedemptionSourceChainKey,
-  selectWithdrawalFee,
+  selectWithdrawSlippage,
 } from '@/store/slices/networkAssets'
 import { WAD, bigIntToNumberAsString } from '@/utils/bigint'
 import { useSelector } from 'react-redux'
@@ -30,7 +30,7 @@ export const useRedeemSummaryData = () => {
   const withdrawalDestinationChainKey = useSelector(selectRedemptionDestinationChainKey)
   const redemptionSourceChainKey = useSelector(selectRedemptionSourceChainKey)
 
-  const withdrawalFee = useSelector(selectWithdrawalFee)
+  const withdrawSlippage = useSelector(selectWithdrawSlippage)
 
   const networkAssetConfig = useSelector(selectNetworkAssetConfig)
   const isBridgeRequired = useSelector(selectIsBridgeRequired)
@@ -71,7 +71,7 @@ export const useRedeemSummaryData = () => {
     rateInQuoteWithFee,
     withdrawalDestinationChainKey,
     redemptionSourceChainKey,
-    withdrawalFee,
+    withdrawSlippage,
     isBridgeRequired,
     tokenKeys,
     receiveToken,

--- a/store/slices/networkAssets/selectors.ts
+++ b/store/slices/networkAssets/selectors.ts
@@ -1,6 +1,6 @@
 import { CrossChainTellerBase } from '@/api/contracts/Teller/previewFee'
 import { Chain, chainsConfig } from '@/config/chains'
-import { defaultWithdrawalFee, hardcodedApy, nativeAddress } from '@/config/constants'
+import { defaultWithdrawSlippage, hardcodedApy, nativeAddress } from '@/config/constants'
 import { NetworkKey, networksConfig } from '@/config/networks'
 import { tokensConfig } from '@/config/tokens'
 import { RootState } from '@/store'
@@ -909,26 +909,26 @@ export const selectWantAssetAddress = (state: RootState) => {
 }
 
 // DO NOT memoize: Returns a primitive value; memoization not necessary.
-// Returns withdrawal fee for selected receive token
-export const selectWithdrawalFee = (state: RootState): number => {
+// Returns withdrawal slippage for selected receive token
+export const selectWithdrawSlippage = (state: RootState): number => {
   const chainConfig = selectNetworkAssetConfig(state)
   const redemptionDestinationChainKey = selectRedemptionDestinationChainKey(state)
   const receiveTokenKey = selectReceiveTokenKey(state)
 
   if (!chainConfig || !redemptionDestinationChainKey || !receiveTokenKey) {
-    return defaultWithdrawalFee
+    return defaultWithdrawSlippage
   }
 
-  const withdrawalFee =
-    chainConfig.redeem.wantTokens[redemptionDestinationChainKey as ChainKey]?.[receiveTokenKey]?.withdrawalFee
+  const withdrawalSlippage =
+    chainConfig.redeem.wantTokens[redemptionDestinationChainKey as ChainKey]?.[receiveTokenKey]?.withdrawSlippage
   // Allow 0 but use default for null/undefined
-  return withdrawalFee !== null && withdrawalFee !== undefined ? withdrawalFee : defaultWithdrawalFee
+  return withdrawalSlippage !== null && withdrawalSlippage !== undefined ? withdrawalSlippage : defaultWithdrawSlippage
 }
 
 // DO NOT memoize: Returns a primitive value; memoization not necessary.
-export const selectWithdrawalFeeAsBigInt = (state: RootState): bigint => {
-  const withdrawalFee = selectWithdrawalFee(state)
-  return withdrawalFee ? BigInt(withdrawalFee * WAD.number) : BigInt(0)
+export const selectWithdrawSlippageAsBigInt = (state: RootState): bigint => {
+  const withdrawSlippage = selectWithdrawSlippage(state)
+  return withdrawSlippage ? BigInt(withdrawSlippage * WAD.number) : BigInt(0)
 }
 
 export const selectWithdrawalSourceExplorerBaseUrl = (state: RootState) => {

--- a/types/Chain.ts
+++ b/types/Chain.ts
@@ -43,9 +43,9 @@ export interface NetworkAsset {
     redemptionSourceAsset: TokenKey
     redemptionSourceChain: ChainKey
     redemptionSourceChains: Partial<Record<ChainKey, { chain: ChainKey; explorerBaseUrl: string }>>
-    wantTokens: Partial<Record<ChainKey, Partial<Record<TokenKey, { token: Token; withdrawalFee: number }>>>>
+    wantTokens: Partial<Record<ChainKey, Partial<Record<TokenKey, { token: Token; withdrawSlippage: number }>>>>
     withdrawalChain: ChainKey
-    withdrawalFee: number
+    withdrawSlippage: number
   }
   receiveOn: ChainKey
   redeemComingSoon?: boolean

--- a/utils/withdrawal.ts
+++ b/utils/withdrawal.ts
@@ -2,24 +2,24 @@ import { tokensConfig } from '@/config/tokens'
 import { Address } from 'viem'
 import { WAD } from './bigint'
 
-export const calculateWithdrawalFee = (amount: bigint, feePercentage: number) => {
+export const calculateWithdrawSlippage = (amount: bigint, slippagePercentage: number) => {
   // Convert percentage to WAD-based calculation
-  // feePercentage * WAD / 100 gives us the WAD-adjusted percentage
-  const feeWad = (BigInt(Math.round(feePercentage * 100)) * WAD.bigint) / BigInt(10000)
+  // slippagePercentage * WAD / 100 gives us the WAD-adjusted percentage
+  const slippageWad = (BigInt(Math.round(slippagePercentage * 100)) * WAD.bigint) / BigInt(10000)
 
-  // Multiply amount by fee and divide by WAD to get final amount
-  return (amount * feeWad) / WAD.bigint
+  // Multiply amount by slippage and divide by WAD to get final amount
+  return (amount * slippageWad) / WAD.bigint
 }
 
 /**
- * Reduces an amount by a fee percentage
+ * Reduces an amount by a slippage percentage
  * @param amount - The base amount as a BigInt (in WAD precision)
- * @param feePercentage - The fee percentage as a number (e.g., 0.2 for 0.2%)
- * @returns The amount reduced by the fee percentage
+ * @param slippagePercentage - The slippage percentage as a number (e.g., 0.2 for 0.2%)
+ * @returns The amount reduced by the slippage percentage
  */
-export const applyWithdrawalFeeReduction = (amount: bigint, feePercentage: number): bigint => {
+export const applyWithdrawSlippageReduction = (amount: bigint, slippagePercentage: number): bigint => {
   // Convert percentage to basis points and subtract from 10000
-  const basisPoints = BigInt(10000) - BigInt(Math.round(feePercentage * 100))
+  const basisPoints = BigInt(10000) - BigInt(Math.round(slippagePercentage * 100))
 
   // Multiply by adjusted basis points and divide by 10000
   return (amount * basisPoints) / BigInt(10000)


### PR DESCRIPTION
# PR: Rename withdrawFee to withdrawSlippage for clarity

## Summary
This PR renames the `withdrawFee` concept to `withdrawSlippage` throughout the codebase to better reflect its actual purpose and behavior in the withdrawal process. This is primarily a terminology change to improve clarity and understanding.

## Changes
- Renamed `withdrawFee` to `withdrawSlippage` across components and configuration files
- Updated related function names (e.g., `applyWithdrawalFeeReduction` → `applyWithdrawSlippageReduction`)
- Updated constant name from `defaultWithdrawalFee` to `defaultWithdrawSlippage`
- Updated tooltip and label text to better explain the slippage concept
- Updated the atomic queue contract address

## Key Updates
- More accurate terminology: "Withdraw Slippage" better describes the mechanism that incentivizes solvers to process withdrawal orders
- Updated tooltip text to be more descriptive: "Withdrawal slippage is the amount of slippage that is applied to the withdrawal. This slippage is applied in order to incentivize solvers to process withdraw orders into arbitrary requested assets."
- Consistent formatting of slippage values using `Number().toFixed(2)`
- Updated AtomicQueue address
- Updated BobaETH slippage fee to 1.00%

